### PR TITLE
Fix error with lists of chars instead of str in msa construction

### DIFF
--- a/proteingym/baselines/esm/compute_fitness.py
+++ b/proteingym/baselines/esm/compute_fitness.py
@@ -79,6 +79,7 @@ def sample_msa(filename: str, nseq: int, sampling_strategy: str, random_seed: in
 
         print("Check sum weights MSA: "+str(non_wt_weights.sum()))
 
+    msa = [(desc, ''.join(seq) if isinstance(seq, list) else seq) for desc, seq in msa]
     msa = [(desc, seq.upper()) for desc, seq in msa]
     print("First 10 elements of sampled MSA: ")
     print(msa[:10])


### PR DESCRIPTION
It seems there is a bug in a new version of MSA processing. I was not able to reproduce MSA Transformer on zero-shot scoring because of the bug. This small changes fixes it and I was able to run MSA Transformer and get comparable performance (using 1 of 5 seeds in ensemble).