### PR TITLE
Add ESMC+TabICLv2 supervised

### DIFF
--- a/config.json
+++ b/config.json
@@ -1277,6 +1277,13 @@
             "location": "kermut",
             "key": "mutant",
             "model_type": "Structure & sequence embedding"
+        },
+        "ESMC-TabICL": {
+            "input_score_name": "y_pred",
+            "label_name": "y",
+            "location": "esmc_tabicl",
+            "key": "mutant",
+            "model_type": "Sequence embedding"
         }
     },
     "model_list_supervised_indels_DMS": {

--- a/proteingym/baselines/esmc_tabicl/README.md
+++ b/proteingym/baselines/esmc_tabicl/README.md
@@ -51,6 +51,13 @@ python compute_scores.py ... --dms_index 13
 
 See `score_all.sh` for the exact invocation used to produce the submitted scores.
 
+## Precomputed scores
+
+Per-mutant predictions for all 217 substitution assays × 3 CV splits (layout
+`model_scores/supervised_substitutions/<cv_scheme>/esmc_tabicl/<DMS_id>.csv`, columns
+`mutant,y,y_pred,fold`) are available here:
+https://github.com/calvinmccarter/esmc_tabicl_eval/releases/download/v1/esmc_tabicl_supervised_substitutions_scores.zip
+
 ## Notes
 - Each TabICL fit peaks ~80 GB GPU memory at n=10k; folds with >10k training rows are seeded-
   subsampled to 10k (`TRAIN_CAP`). The held-out fold is never subsampled (all mutants are scored).

--- a/proteingym/baselines/esmc_tabicl/README.md
+++ b/proteingym/baselines/esmc_tabicl/README.md
@@ -1,0 +1,57 @@
+# ESMC-TabICL
+
+Supervised variant-effect predictor for the ProteinGym substitution benchmark: **ESMC-600M
+embeddings + zero-shot scores → TabICLv2 regression**. No GP, no structure, no MSA.
+
+## Method
+
+For each variant, `compute_scores.py` builds a 1164-dim feature vector:
+
+| feature | dims | description |
+|---|---|---|
+| embedding | 1152 | ESMC-600M `hidden_states[-2]` (second-to-last layer), mean-pooled over residues |
+| pseudo-LL | 1 | approximate pseudo-log-likelihood — one **unmasked** forward pass, `Σ_i log P(s_i \| s)` |
+| masked wt-marginal | 11 | **masked** mutation-effect score (mask each mutated position in the wild type, read the blind prediction `log P[mut] − log P[wt]`), aggregated as deciles over the mutated positions |
+
+These features go to a [TabICLv2](https://github.com/soda-inria/tabicl) regressor under ProteinGym's
+CV protocol: for each split, train on 4 folds and predict the held-out fold, with targets
+standardized per fold. Output: one score file per assay per split,
+`<output_dir>/<cv_scheme>/<DMS_id>.csv` with columns `[mutant, y, y_pred, fold]`.
+
+The masked wt-marginal is the ESM "wt-marginals" zero-shot score (Meier et al., 2021) in its masked
+form. The decile aggregation is identity for single mutants (it up-weights this strong scalar) and
+generalizes to multi-mutation assays.
+
+## Installation
+
+```bash
+python -m venv venv && source venv/bin/activate
+pip install torch --index-url https://download.pytorch.org/whl/cu130
+pip install "esm@git+https://github.com/Biohub/esm.git@main"   # provides biohub/ESMC-600M + esmc arch
+pip install tabicl scipy pandas numpy
+```
+`biohub/ESMC-600M` (≈2.4 GB) downloads from the HuggingFace Hub on first use. Both ESMC-600M and
+TabICLv2 are open source.
+
+## Usage
+
+```bash
+# all 217 assays (loads the model once, loops assays)
+python compute_scores.py \
+    --dms_reference  ../../../reference_files/DMS_substitutions.csv \
+    --dms_folder     <path to cv_folds_singles_substitutions> \
+    --output_dir     <scores_out>
+
+# a single assay (row index in the reference file), e.g. for parallel scoring
+python compute_scores.py ... --dms_index 13
+```
+
+`--dms_folder` is the per-assay CV-fold CSVs from ProteinGym (columns `mutant`,
+`mutated_sequence`, `DMS_score`, `fold_random_5`, `fold_modulo_5`, `fold_contiguous_5`).
+
+See `score_all.sh` for the exact invocation used to produce the submitted scores.
+
+## Notes
+- Each TabICL fit peaks ~80 GB GPU memory at n=10k; folds with >10k training rows are seeded-
+  subsampled to 10k (`TRAIN_CAP`). The held-out fold is never subsampled (all mutants are scored).
+- fp32 forward passes; bf16 gives essentially identical results (embeddings cosine 0.99997).

--- a/proteingym/baselines/esmc_tabicl/compute_scores.py
+++ b/proteingym/baselines/esmc_tabicl/compute_scores.py
@@ -1,0 +1,157 @@
+"""ESMC-TabICL: supervised variant-effect prediction on the ProteinGym substitution benchmark.
+
+For each DMS assay, features per variant are:
+  - ESMC-600M second-to-last-layer (hidden_states[-2]) embedding, mean-pooled over residues  (1152)
+  - approximate pseudo-log-likelihood: one unmasked forward pass, sum_i log P(s_i | s)          (1)
+  - masked wt-marginal mutation-effect score (mask each mutated position in the wild type, read
+    the blind prediction logP[mut]-logP[wt]), aggregated as deciles over the mutated positions    (11)
+These 1164 features go to a TabICLv2 regressor under ProteinGym's CV protocol (train on 4 folds,
+predict the held-out fold; targets standardized per fold). One score file per assay per CV split:
+    <output_dir>/<cv_scheme>/<DMS_id>.csv  with columns [mutant, y, y_pred, fold].
+
+Usage:
+    python compute_scores.py --dms_reference reference_files/DMS_substitutions.csv \
+        --dms_folder <cv_folds_singles_substitutions> --output_dir <scores_out> [--dms_index N]
+
+Both ESMC-600M (biohub/ESMC-600M) and TabICLv2 (tabicl) are open source.
+"""
+import argparse, os, re
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn.functional as F
+from scipy.stats import spearmanr
+from transformers import AutoModelForMaskedLM, AutoTokenizer
+from tabicl import TabICLRegressor
+
+MODEL = "biohub/ESMC-600M"
+CV_SCHEMES = ["fold_random_5", "fold_modulo_5", "fold_contiguous_5"]
+TOKEN_BUDGET = 60000     # tokens/batch for the forward passes
+TRAIN_CAP = 10000        # cap training context (a single TabICL fit peaks ~80GB at n=10k)
+DECILES = list(range(0, 101, 10))
+MUT_RE = re.compile(r"^([A-Za-z])(\d+)([A-Za-z])$")
+
+
+def parse_muts(mut):
+    return [(m.group(1), int(m.group(2)), m.group(3))
+            for m in (MUT_RE.match(p) for p in str(mut).split(":"))]
+
+
+def derive_wt(df):
+    """Reconstruct the wild-type sequence by reverting any variant's mutation(s)."""
+    seq = list(df["mutated_sequence"].iloc[0])
+    for wt_aa, pos, mut_aa in parse_muts(df["mutant"].iloc[0]):
+        seq[pos - 1] = wt_aa
+    return "".join(seq)
+
+
+def batched(seqs, budget=TOKEN_BUDGET):
+    order = sorted(range(len(seqs)), key=lambda i: len(seqs[i]))
+    i = 0
+    while i < len(order):
+        j, Lmax = i, len(seqs[order[i]]) + 2
+        while j < len(order):
+            L = max(Lmax, len(seqs[order[j]]) + 2)
+            if (j - i + 1) * L > budget and j > i:
+                break
+            Lmax = L; j += 1
+        yield order[i:j]
+        i = j
+
+
+@torch.inference_mode()
+def featurize(df, tok, model, dev):
+    """Return (emb (N,1152), pll (N,), wtdec (N,11)) for all variants in an assay."""
+    seqs = df["mutated_sequence"].tolist()
+    n, d = len(seqs), model.config.d_model
+    cls, eos, pad = tok.cls_token_id, tok.eos_token_id, tok.pad_token_id
+    cap = {}
+    h = model.esmc.transformer.blocks[-2].register_forward_hook(
+        lambda m, i, o: cap.__setitem__("h", o[0] if isinstance(o, tuple) else o))
+
+    # (1+2) per-variant emb (mean-pooled second-to-last layer) and approximate pseudo-LL
+    emb = np.zeros((n, d), np.float32); pll = np.zeros(n, np.float32)
+    for idx in batched(seqs):
+        enc = tok([seqs[k] for k in idx], return_tensors="pt", padding=True).to(dev)
+        ids = enc["input_ids"]
+        logits = model(**enc).logits
+        keep = enc["attention_mask"].bool() & (ids != cls) & (ids != eos) & (ids != pad)
+        mm = keep.unsqueeze(-1).to(cap["h"].dtype)
+        pooled = (cap["h"] * mm).sum(1) / mm.sum(1).clamp_min(1.0)
+        lp = F.log_softmax(logits, -1).gather(-1, ids.unsqueeze(-1)).squeeze(-1)
+        sp = (lp * keep).sum(1)
+        for r, k in enumerate(idx):
+            emb[k] = pooled[r].float().cpu().numpy(); pll[k] = float(sp[r])
+    h.remove()
+
+    # (3) masked wt-marginal: mask each unique mutated position in the WT once
+    wt = derive_wt(df)
+    base = tok([wt], return_tensors="pt")["input_ids"][0]
+    positions = sorted({p for mut in df["mutant"] for _, p, _ in parse_muts(mut)})
+    Lt = base.shape[0]; bs = max(1, TOKEN_BUDGET // Lt)
+    logp_at = {}
+    for s in range(0, len(positions), bs):
+        chunk = positions[s:s + bs]
+        bt = base.unsqueeze(0).repeat(len(chunk), 1).clone()
+        for r, p in enumerate(chunk):
+            bt[r, p] = tok.mask_token_id
+        out = model(input_ids=bt.to(dev), attention_mask=torch.ones_like(bt).to(dev)).logits
+        for r, p in enumerate(chunk):
+            logp_at[p] = F.log_softmax(out[r, p].float(), -1).cpu().numpy()
+    aa = {}
+    wtdec = np.zeros((n, len(DECILES)), np.float32)
+    for r, mut in enumerate(df["mutant"]):
+        sc = []
+        for wt_aa, pos, mut_aa in parse_muts(mut):
+            wi = aa.setdefault(wt_aa, tok.convert_tokens_to_ids(wt_aa))
+            mi = aa.setdefault(mut_aa, tok.convert_tokens_to_ids(mut_aa))
+            sc.append(logp_at[pos][mi] - logp_at[pos][wi])
+        wtdec[r] = np.percentile(np.array(sc), DECILES)
+    return emb, pll.reshape(-1, 1), wtdec
+
+
+def score_assay(df, X, out_dir, dms_id):
+    y = df["DMS_score"].to_numpy(np.float64)
+    for scheme in CV_SCHEMES:
+        folds = df[scheme].to_numpy()
+        y_true = np.full(len(df), np.nan); y_pred = np.full(len(df), np.nan)
+        for f in np.unique(folds):
+            tr = np.where(folds != f)[0]; te = folds == f
+            if len(tr) > TRAIN_CAP:
+                rng = np.random.default_rng(abs(hash((dms_id, scheme, int(f)))) % 2**32)
+                tr = np.sort(rng.choice(tr, TRAIN_CAP, replace=False))
+            mu, sd = y[tr].mean(), (y[tr].std() or 1.0)
+            reg = TabICLRegressor(random_state=42)
+            reg.fit(X[tr], (y[tr] - mu) / sd)
+            y_pred[te] = reg.predict(X[te]); y_true[te] = (y[te] - mu) / sd
+        d = os.path.join(out_dir, scheme); os.makedirs(d, exist_ok=True)
+        pd.DataFrame({"mutant": df["mutant"], "y": y_true, "y_pred": y_pred, "fold": folds}
+                     ).to_csv(os.path.join(d, dms_id + ".csv"), index=False)
+        rho = spearmanr(y_true, y_pred).correlation
+        print(f"  {dms_id} {scheme} Spearman={rho:.3f}", flush=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dms_reference", required=True)
+    ap.add_argument("--dms_folder", required=True, help="folder of per-assay CV-fold CSVs")
+    ap.add_argument("--output_dir", required=True)
+    ap.add_argument("--dms_index", type=int, default=-1, help="score one assay (row in reference); default all")
+    ap.add_argument("--device", default="cuda:0")
+    args = ap.parse_args()
+
+    ref = pd.read_csv(args.dms_reference)
+    ids = [ref["DMS_id"].iloc[args.dms_index]] if args.dms_index >= 0 else list(ref["DMS_id"])
+    tok = AutoTokenizer.from_pretrained(MODEL)
+    model = AutoModelForMaskedLM.from_pretrained(MODEL, dtype=torch.float32).to(args.device).eval()
+
+    for dms_id in ids:
+        fn = ref.loc[ref.DMS_id == dms_id, "DMS_filename"].values[0]
+        df = pd.read_csv(os.path.join(args.dms_folder, fn))
+        emb, pll, wtdec = featurize(df, tok, model, args.device)
+        X = np.concatenate([emb, pll, wtdec], axis=1).astype(np.float32)
+        score_assay(df, X, args.output_dir, dms_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/proteingym/baselines/esmc_tabicl/requirements.txt
+++ b/proteingym/baselines/esmc_tabicl/requirements.txt
@@ -1,0 +1,9 @@
+# ESMC-TabICL baseline dependencies
+# torch: install the CUDA build matching your system, e.g.
+#   pip install torch --index-url https://download.pytorch.org/whl/cu130
+torch
+esm @ git+https://github.com/Biohub/esm.git@main   # biohub/ESMC-600M + esmc architecture (+ transformers fork)
+tabicl>=2.1.1
+scipy
+pandas
+numpy

--- a/proteingym/baselines/esmc_tabicl/score_all.sh
+++ b/proteingym/baselines/esmc_tabicl/score_all.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Produce ESMC-TabICL score files for the full substitution benchmark.
+# Output layout: $OUTPUT_DIR/<cv_scheme>/<DMS_id>.csv  (columns: mutant, y, y_pred, fold)
+set -e
+DMS_REFERENCE=../../../reference_files/DMS_substitutions.csv
+DMS_FOLDER=${DMS_FOLDER:?set DMS_FOLDER to the cv_folds_singles_substitutions directory}
+OUTPUT_DIR=${OUTPUT_DIR:-./scores}
+
+python compute_scores.py \
+    --dms_reference "$DMS_REFERENCE" \
+    --dms_folder    "$DMS_FOLDER" \
+    --output_dir    "$OUTPUT_DIR" \
+    --device        cuda:0

--- a/proteingym/constants.json
+++ b/proteingym/constants.json
@@ -322,7 +322,8 @@
         "DeepSequence + One-Hot Encodings": "DeepSequence + One-Hot Encodings",
         "MSA_Transformer + One-Hot Encodings": "MSA Transformer + One-Hot Encodings",
         "One-Hot Encodings": "One-Hot Encodings",
-        "Kermut": "Kermut GP"
+        "Kermut": "Kermut GP",
+        "ESMC-TabICL": "ESMC-600M embeddings + zero-shot scores, TabICLv2 regression"
     },
     "supervised_model_references":{
         "ProteinNPT": "<a href='https://openreview.net/forum?id=AwzbQVuDBk'>Notin, P., Weitzman, R., Marks, D. S., & Gal, Y. (2023). ProteinNPT: Improving protein property prediction and design with non-parametric transformers. Thirty-Seventh Conference on Neural Information Processing Systems</a>",
@@ -336,6 +337,7 @@
         "MSA_Transformer + One-Hot Encodings":"[1] Original model: <a href='http://proceedings.mlr.press/v139/rao21a.html'>Rao, R., Liu, J., Verkuil, R., Meier, J., Canny, J.F., Abbeel, P., Sercu, T., & Rives, A. (2021). MSA Transformer. ICML.</a> [2] Extension: <a href='https://openreview.net/forum?id=AwzbQVuDBk'>Notin, P., Weitzman, R., Marks, D. S., & Gal, Y. (2023). ProteinNPT: Improving protein property prediction and design with non-parametric transformers. Thirty-Seventh Conference on Neural Information Processing Systems</a>",
         "One-Hot Encodings":"<a href='https://www.nature.com/articles/s41587-021-01146-5'>Hsu, C., Nisonoff, H., Fannjiang, C. et al. Learning protein fitness models from evolutionary and assay-labeled data. Nat Biotechnol 40, 1114–1122 (2022). https://doi.org/10.1038/s41587-021-01146-5</a>",
         "Kermut":"<a href='https://openreview.net/forum?id=jM9atrvUii'>Groth, P. M., Kerrn, M. H., Olsen, L., Salomon, J., & Boomsma, W. (2024). Kermut: Composite kernel regression for protein variant effects. Thirty-Eighth Conference on Neural Information Processing Systems</a>",
+        "ESMC-TabICL":"[1] ESMC: <a href='https://www.biorxiv.org/content/10.1101/2024.12.04.626885v1'>ESM Team (2024). ESM Cambrian: Revealing the mysteries of proteins with unsupervised learning.</a> [2] TabICL: <a href='https://arxiv.org/abs/2502.05564'>Qu, J., Holzmüller, D., Varoquaux, G., & Le Morvan, M. (2025). TabICL: A Tabular Foundation Model for In-Context Learning on Large Data. ICML.</a>",
         "Embeddings_MSA_Transformer_indels":"[1] Original model: <a href='http://proceedings.mlr.press/v139/rao21a.html'>Rao, R., Liu, J., Verkuil, R., Meier, J., Canny, J.F., Abbeel, P., Sercu, T., & Rives, A. (2021). MSA Transformer. ICML.</a> [2] Extension: <a href='https://openreview.net/forum?id=AwzbQVuDBk'>Notin, P., Weitzman, R., Marks, D. S., & Gal, Y. (2023). ProteinNPT: Improving protein property prediction and design with non-parametric transformers. Thirty-Seventh Conference on Neural Information Processing Systems</a>",
         "Embeddings_ESM1v_indels":"[1] Original model: <a href='https://proceedings.neurips.cc/paper/2021/hash/f51338d736f95dd42427296047067694-Abstract.html'>Meier, J., Rao, R., Verkuil, R., Liu, J., Sercu, T., & Rives, A. (2021). Language models enable zero-shot prediction of the effects of mutations on protein function. NeurIPS.</a> [2] Extension: <a href='https://openreview.net/forum?id=AwzbQVuDBk'>Notin, P., Weitzman, R., Marks, D. S., & Gal, Y. (2023). ProteinNPT: Improving protein property prediction and design with non-parametric transformers. Thirty-Seventh Conference on Neural Information Processing Systems</a>",
         "Embeddings_Tranception_indels":"[1] Original model: <a href='https://proceedings.mlr.press/v162/notin22a.html'>Notin, P., Dias, M., Frazer, J., Marchena-Hurtado, J., Gomez, A.N., Marks, D.S., & Gal, Y. (2022). Tranception: Protein Fitness Prediction with Autoregressive Transformers and Inference-time Retrieval. ICML.</a> [2] Extension: <a href='https://openreview.net/forum?id=AwzbQVuDBk'>Notin, P., Weitzman, R., Marks, D. S., & Gal, Y. (2023). ProteinNPT: Improving protein property prediction and design with non-parametric transformers. Thirty-Seventh Conference on Neural Information Processing Systems</a>"
@@ -352,6 +354,7 @@
         "OHE - Augmented - ESM1v":"ESM-1v + One-Hot Encodings",
         "OHE - Not augmented":"One-Hot Encodings",
         "Kermut":"Kermut",
+        "ESMC-TabICL":"ESMC-TabICL",
         "Embeddings_ESM1v_indels": "ESM-1v Embeddings",
         "Embeddings_MSA_Transformer_indels": "MSA Transformer Embeddings",
         "Embeddings_Tranception_indels": "Tranception Embeddings"
@@ -368,6 +371,7 @@
         "ESM-1v + One-Hot Encodings":"One-hot Encoding",
         "One-Hot Encodings":"One-hot Encoding",
         "Kermut": "Structure & sequence embedding",
+        "ESMC-TabICL": "Sequence embedding",
         "Embeddings_ESM1v_indels": "Sequence embedding",
         "Embeddings_MSA_Transformer_indels": "Sequence embedding",
         "Embeddings_Tranception_indels": "Sequence embedding"


### PR DESCRIPTION
This PR adds **ESMC-TabICLv2**, a supervised variant-effect predictor for the DMS substitution
benchmark: mean-pooled ESMC-600M embeddings, PLL, and WT marginal scores, fed to a TabICLv2 tabular foundation-model regressor under the standard 5-fold CV protocol. This approach uses no GP, MSA, or structure, yet comes in second place just below Kermut.

Features per variant (1164 dims): ESMC-600M second-to-last-layer embedding mean-pooled over residues
(1152); an approximate (single unmasked pass) pseudo-log-likelihood (1); and the masked wt-marginal
mutation-effect score aggregated as deciles (11).

Changes:
- `proteingym/baselines/esmc_tabicl/` — self-contained scoring script (`compute_scores.py`), README,
  `requirements.txt`, and `score_all.sh`.
- `config.json` — new `ESMC-TabICL` entry under `model_list_supervised_substitutions_DMS`.
- `proteingym/constants.json` — clean name, references, model details, model type.
- `benchmarks/DMS_supervised/substitutions/{Spearman,MSE}/`: Summary + DMS-level files regenerated
  with ESMC-TabICL included (computed with `performance_DMS_supervised_benchmarks.py`).

Per-mutant score files for all 217 assays × 3 CV splits are available at:
https://github.com/calvinmccarter/esmc_tabicl_eval/releases/download/v1/esmc_tabicl_supervised_substitutions_scores.zip
(layout `model_scores/supervised_substitutions/<cv_scheme>/esmc_tabicl/<DMS_id>.csv`, columns `mutant,y,y_pred,fold`).

Both ESMC-600M (`biohub/ESMC-600M`) and TabICLv2 are open source. The method scores all mutants in
the substitution benchmark (217/217 assays).

**Official performance** (via `performance_DMS_supervised_benchmarks.py`): Average Spearman 0.630
(random 0.749, modulo 0.591, contiguous 0.550): rank 2, behind Kermut (0.657) and ahead of
ProteinNPT (0.619).