### PR TITLE
Add XSignal zero-shot baseline

### DIFF
--- a/proteingym/baselines/xsignal/README.md
+++ b/proteingym/baselines/xsignal/README.md
@@ -1,0 +1,23 @@
+# XSignal
+
+XSignal is a zero-shot evidence-integration method for ProteinGym substitution assays.
+It derives 14 mutation-scoring channels from ProteinGym MSAs, MSA sequence
+weights, precomputed AlphaFold2 structures, and fixed amino-acid physicochemical
+descriptors. Each channel is transformed into assay-wise percentile ranks and
+the final score is the equal-weight average of the 14 calibrated channels.
+
+The output score column is `XSignal_score`, with higher scores indicating higher
+predicted function or fitness.
+
+The scorer reads only variant-key columns from DMS assay files:
+
+- `mutant`
+- `mutated_sequence`
+
+It does not read DMS labels, binary labels, supervised folds, public baseline
+score packages, or official merged-score files during final scoring.
+
+XSignal does not use pretrained protein language model weights. It does use
+ProteinGym's precomputed AlphaFold2 structures and ten self-generated
+intermediate XSignal evidence folders. The example scoring shell script documents
+the expected intermediate folder layout.

--- a/proteingym/baselines/xsignal/compute_fitness.py
+++ b/proteingym/baselines/xsignal/compute_fitness.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""XSignal zero-shot scorer for ProteinGym substitution assays.
+
+XSignal is the public name for the frozen internal candidate
+PureGraphGEContactPair_v1. The submitted score is a 14-channel assay-wise
+percentile-rank ensemble over MSA, AlphaFold2-structure, and fixed residue
+chemistry evidence.
+
+This script intentionally reads only variant-key columns from DMS assay files:
+`mutant` and `mutated_sequence`. It does not read DMS labels, binary labels,
+supervised folds, public baseline score packages, or official merged scores.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from xsignal_core.a2m import load_proteingym_focus_sequences, load_weights, weighted_conservation
+from xsignal_core.sensors import (
+    contact_pair_ge_score,
+    msa_structure_joint_composable_score,
+    structure_context_composable_score,
+    tm_stability_composable_score,
+)
+from xsignal_core.structure import parse_af2_structure
+
+
+LEGACY_SENSORS = {
+    "rsalor_like": ("PureRSALORLike_v1", "PureRSALORLike_score"),
+    "context": ("PureContextRank_v1", "PureContextRank_score"),
+    "family_mlm": ("PureFamilyConvMLM_v1", "PureFamilyConvMLM_score"),
+    "family_vae": ("PureFamilyVAE_v1", "PureFamilyVAE_score"),
+    "structure_energy": ("PureStructureEnergy_v1", "PureStructureEnergy_score"),
+    "potts_pll": ("PurePottsPLL_v1", "PurePottsPLL_score"),
+    "tt_physics": ("PureTTPhysics_v1", "PureTTPhysics_score"),
+    "contextual_msa": ("PureContextualMSA_v1b", "PureContextualMSA_score"),
+    "subfamily_msa": ("PureSubfamilyMSA_v1", "PureSubfamilyMSA_score"),
+    "structure_graph": ("PureStructureGraph_v1", "PureStructureGraph_score"),
+}
+EXPECTED_SENSOR_COUNT = 14
+SCORE_NAME = "XSignal_score"
+
+
+def rank01(values: pd.Series | np.ndarray) -> np.ndarray:
+    numeric = pd.to_numeric(pd.Series(values), errors="coerce")
+    if numeric.isna().any():
+        raise ValueError("rank input contains non-numeric values")
+    return numeric.rank(method="average", pct=True).to_numpy(dtype=np.float64)
+
+
+def parse_start(value: object) -> int:
+    text = str(value)
+    try:
+        return int(text.split("-")[0])
+    except (TypeError, ValueError, IndexError):
+        raise ValueError(f"invalid pdb_range start: {value}") from None
+
+
+def read_variant_keys(path: Path) -> pd.DataFrame:
+    header = pd.read_csv(path, nrows=0)
+    usecols = [column for column in ("mutant", "mutated_sequence") if column in header.columns]
+    if not usecols:
+        raise ValueError(f"{path} is missing mutant/mutated_sequence columns")
+    frame = pd.read_csv(path, usecols=usecols)
+    if "mutated_sequence" not in frame.columns:
+        frame["mutated_sequence"] = frame["mutant"]
+    if "mutant" not in frame.columns:
+        frame["mutant"] = frame["mutated_sequence"]
+    if frame["mutated_sequence"].isna().any() or frame["mutant"].isna().any():
+        raise ValueError(f"{path} contains null variant keys")
+    return frame[["mutant", "mutated_sequence"]]
+
+
+def aligned_legacy_sensor(path: Path, assay_frame: pd.DataFrame, score_column: str) -> np.ndarray:
+    frame = pd.read_csv(path, usecols=["mutated_sequence", score_column])
+    frame[score_column] = pd.to_numeric(frame[score_column], errors="coerce")
+    if frame[score_column].isna().any():
+        raise ValueError(f"non-finite legacy sensor values: {path}")
+    compact = (
+        frame.drop_duplicates("mutated_sequence")
+        .groupby("mutated_sequence", as_index=False)
+        .mean(numeric_only=True)
+    )
+    merged = assay_frame[["mutated_sequence"]].merge(compact, on="mutated_sequence", how="left", sort=False)
+    if merged[score_column].isna().any():
+        raise ValueError(f"legacy sensor does not cover all variants: {path}")
+    return rank01(merged[score_column].to_numpy(dtype=np.float64))
+
+
+def corrected_msa_conservation_with_metadata(
+    msa_path: Path,
+    weight_path: Path,
+    start: int,
+    end: int,
+) -> tuple[dict[int, float], dict[str, int]]:
+    sequences, metadata = load_proteingym_focus_sequences(
+        msa_path,
+        threshold_sequence_frac_gaps=0.5,
+        threshold_focus_cols_frac_gaps=1.0,
+        remove_indeterminate=True,
+    )
+    expected_length = end - start + 1
+    if metadata["msa_focus_length"] != expected_length:
+        raise ValueError(
+            f"MSA focus length mismatch: {msa_path}: focus={metadata['msa_focus_length']}, expected={expected_length}"
+        )
+    weights = load_weights(weight_path, len(sequences))
+    metadata = dict(metadata)
+    metadata["msa_weight_sequences"] = int(len(weights))
+    metadata["msa_weight_sum_floor"] = int(np.floor(weights.sum()))
+    return weighted_conservation(sequences, weights, start, end), metadata
+
+
+def score_assay(row: pd.Series, args: argparse.Namespace, structure_cache: dict, msa_cache: dict) -> dict:
+    started = time.perf_counter()
+    dms_id = str(row["DMS_id"])
+    dms_path = args.DMS_data_folder / str(row["DMS_filename"])
+    assay = read_variant_keys(dms_path)
+
+    components: list[np.ndarray] = []
+    for sensor_name, (folder_name, score_column) in LEGACY_SENSORS.items():
+        sensor_path = args.legacy_score_folder / folder_name / f"{dms_id}.csv"
+        if not sensor_path.exists():
+            raise FileNotFoundError(f"missing legacy XSignal sensor {sensor_name}: {sensor_path}")
+        components.append(aligned_legacy_sensor(sensor_path, assay, score_column))
+
+    pdb_path = args.AF2_structures_folder / str(row["pdb_file"])
+    structure_key = (str(pdb_path), "A")
+    if structure_key not in structure_cache:
+        structure_cache[structure_key] = parse_af2_structure(pdb_path, chain_id="A")
+    structure = structure_cache[structure_key]
+    pdb_start = parse_start(row["pdb_range"])
+    mutants = assay["mutant"].astype(str)
+
+    msa_path = args.MSA_folder / str(row["MSA_filename"])
+    weight_path = args.MSA_weights_folder / str(row["weight_file_name"])
+    msa_key = (str(msa_path), str(weight_path), int(row["MSA_start"]), int(row["MSA_end"]))
+    if msa_key not in msa_cache:
+        msa_cache[msa_key] = corrected_msa_conservation_with_metadata(
+            msa_path,
+            weight_path,
+            int(row["MSA_start"]),
+            int(row["MSA_end"]),
+        )
+    conservation, msa_metadata = msa_cache[msa_key]
+
+    structure_scores = np.asarray(
+        [structure_context_composable_score(value, structure, pdb_start) for value in mutants],
+        dtype=np.float64,
+    )
+    tm_scores = np.asarray(
+        [tm_stability_composable_score(value, structure, pdb_start) for value in mutants],
+        dtype=np.float64,
+    )
+    joint_scores = np.asarray(
+        [msa_structure_joint_composable_score(value, conservation, structure, pdb_start) for value in mutants],
+        dtype=np.float64,
+    )
+    contact_scores = np.asarray(
+        [contact_pair_ge_score(value, structure, pdb_start) for value in mutants],
+        dtype=np.float64,
+    )
+    components.extend([rank01(structure_scores), rank01(tm_scores), rank01(joint_scores), rank01(contact_scores)])
+    if len(components) != EXPECTED_SENSOR_COUNT:
+        raise ValueError(f"{dms_id}: expected {EXPECTED_SENSOR_COUNT} channels, got {len(components)}")
+
+    score = np.mean(np.column_stack(components), axis=1)
+    if not np.isfinite(score).all():
+        raise ValueError(f"non-finite XSignal scores: {dms_id}")
+
+    output = assay[["mutant", "mutated_sequence"]].copy()
+    output[SCORE_NAME] = score
+    args.output_scores_folder.mkdir(parents=True, exist_ok=True)
+    output.to_csv(args.output_scores_folder / f"{dms_id}.csv", index=False)
+
+    mutation_counts = mutants.str.count(":") + 1
+    metadata = {
+        "DMS_id": dms_id,
+        "status": "ok",
+        "n_rows": int(len(output)),
+        "n_channels": int(len(components)),
+        "elapsed_seconds": round(time.perf_counter() - started, 3),
+        "structure_residues": int(len(structure.aa)),
+        "n_non_single_mutants": int((mutation_counts > 1).sum()),
+        "ge_contact_pair_nonzero_frac": float(np.mean(contact_scores != 0.0)),
+    }
+    metadata.update(msa_metadata)
+    return metadata
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Score ProteinGym substitutions with XSignal.")
+    parser.add_argument("--DMS_reference_file_path", type=Path, required=True)
+    parser.add_argument("--DMS_data_folder", type=Path, required=True)
+    parser.add_argument("--DMS_index", type=int, default=None)
+    parser.add_argument("--output_scores_folder", type=Path, required=True)
+    parser.add_argument("--MSA_folder", type=Path, required=True)
+    parser.add_argument("--MSA_weights_folder", type=Path, required=True)
+    parser.add_argument("--AF2_structures_folder", type=Path, required=True)
+    parser.add_argument(
+        "--legacy_score_folder",
+        type=Path,
+        required=True,
+        help="Folder containing the ten self-generated XSignal legacy sensor score directories.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    reference = pd.read_csv(args.DMS_reference_file_path)
+    if args.DMS_index is not None:
+        reference = reference.iloc[[args.DMS_index]]
+
+    manifest = []
+    structure_cache: dict = {}
+    msa_cache: dict = {}
+    for _, row in reference.iterrows():
+        metadata = score_assay(row, args, structure_cache, msa_cache)
+        manifest.append(metadata)
+        (args.output_scores_folder / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+        )
+
+    summary = {
+        "model": "XSignal",
+        "internal_candidate": "PureGraphGEContactPair_v1",
+        "score_name": SCORE_NAME,
+        "n_assays": sum(item["status"] == "ok" for item in manifest),
+        "n_errors": 0,
+        "formula": "14-channel assay-wise percentile-rank equal fusion",
+        "no_dms_labels_at_inference": True,
+        "no_pretrained_protein_language_model_weights": True,
+        "uses_precomputed_af2_structures": True,
+    }
+    (args.output_scores_folder / "complete.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False) + "\n"
+    )
+    print(json.dumps(summary, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"XSignal scoring failed: {exc}", file=sys.stderr)
+        raise

--- a/proteingym/baselines/xsignal/requirements.txt
+++ b/proteingym/baselines/xsignal/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+pandas
+biopython

--- a/proteingym/baselines/xsignal/xsignal_core/a2m.py
+++ b/proteingym/baselines/xsignal/xsignal_core/a2m.py
@@ -1,0 +1,227 @@
+"""ProteinGym-compatible A2M and MSA preprocessing utilities."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+AA_ORDER = "ACDEFGHIKLMNPQRSTVWY"
+AA_SET = set(AA_ORDER)
+GAP_BYTE = ord("-")
+LOWER_TRANSLATION = np.arange(256, dtype=np.uint8)
+for _aa in AA_ORDER:
+    LOWER_TRANSLATION[ord(_aa)] = ord(_aa.lower())
+VALID_PREPROCESSED_BYTES = np.zeros(256, dtype=bool)
+for _aa in AA_ORDER:
+    VALID_PREPROCESSED_BYTES[ord(_aa)] = True
+    VALID_PREPROCESSED_BYTES[ord(_aa.lower())] = True
+VALID_PREPROCESSED_BYTES[GAP_BYTE] = True
+
+
+def normalize_match_states(sequence: str) -> str:
+    """Remove lowercase insertion states while preserving match-state gaps."""
+
+    return "".join(char for char in sequence.strip() if not char.islower() and char != ".")
+
+
+def parse_a2m_alignment(path: str | Path) -> OrderedDict[str, str]:
+    """Read a raw A2M file and preserve record order and casing."""
+
+    records: OrderedDict[str, str] = OrderedDict()
+    name: str | None = None
+    chunks: list[str] = []
+    with Path(path).open() as handle:
+        for raw_line in handle:
+            line = raw_line.rstrip("\r\n")
+            if line.startswith(">"):
+                if name is not None:
+                    records[name] = "".join(chunks)
+                name = line[1:].strip()
+                chunks = []
+            elif line.strip():
+                chunks.append(line.strip())
+    if name is not None:
+        records[name] = "".join(chunks)
+    if not records:
+        raise ValueError(f"A2M file contains no sequences: {path}")
+    return records
+
+
+def parse_a2m_records(path: str | Path) -> list[str]:
+    """Read an A2M file and return generic normalized match-state sequences."""
+
+    records = [normalize_match_states(sequence) for sequence in parse_a2m_alignment(path).values()]
+    lengths = {len(record) for record in records}
+    if len(lengths) != 1:
+        raise ValueError(f"A2M match-state lengths disagree: {path}: {sorted(lengths)[:8]}")
+    return records
+
+
+def preprocess_records_like_proteingym(
+    records: OrderedDict[str, str],
+    threshold_sequence_frac_gaps: float = 0.5,
+    threshold_focus_cols_frac_gaps: float = 1.0,
+    remove_indeterminate: bool = True,
+) -> OrderedDict[str, str]:
+    """Mirror ProteinGym/EVE preprocessing for the official MSA weights.
+
+    This follows the ProteinGym baseline logic:
+    1. Replace '.' with '-'.
+    2. Uppercase all residues.
+    3. Remove columns that are gaps in the focus sequence.
+    4. Remove fragment-like sequences with too many gaps.
+    5. Mark non-focus columns as lowercase instead of dropping them.
+    6. Optionally drop sequences with indeterminate symbols.
+    """
+
+    if not records:
+        raise ValueError("A2M preprocessing requires at least one record")
+    if not 0.0 <= threshold_sequence_frac_gaps <= 1.0:
+        raise ValueError(f"invalid fragment threshold: {threshold_sequence_frac_gaps}")
+    if not 0.0 <= threshold_focus_cols_frac_gaps <= 1.0:
+        raise ValueError(f"invalid focus threshold: {threshold_focus_cols_frac_gaps}")
+
+    names = list(records)
+    cleaned = [sequence.replace(".", "-").upper() for sequence in records.values()]
+    focus_len = len(cleaned[0])
+    matrix = np.full((len(cleaned), focus_len), GAP_BYTE, dtype=np.uint8)
+    for index, sequence in enumerate(cleaned):
+        encoded = np.frombuffer(sequence.encode("ascii", errors="ignore"), dtype=np.uint8)[:focus_len]
+        matrix[index, : len(encoded)] = encoded
+
+    matrix = matrix[:, matrix[0] != GAP_BYTE]
+    if matrix.shape[1] == 0:
+        raise ValueError("focus-sequence gap filtering removed every column")
+
+    gaps = matrix == GAP_BYTE
+    seq_keep = gaps.mean(axis=1) <= threshold_sequence_frac_gaps
+    if not np.any(seq_keep):
+        raise ValueError("fragment filtering removed every sequence")
+    focus_keep = gaps[seq_keep].mean(axis=0) <= threshold_focus_cols_frac_gaps
+
+    output: OrderedDict[str, str] = OrderedDict()
+    kept_names = [name for name, keep in zip(names, seq_keep, strict=True) if keep]
+    kept_matrix = matrix[seq_keep]
+    if np.all(focus_keep):
+        valid_rows = (
+            VALID_PREPROCESSED_BYTES[kept_matrix].all(axis=1)
+            if remove_indeterminate
+            else np.ones(len(kept_names), dtype=bool)
+        )
+        for name, row, valid in zip(kept_names, kept_matrix, valid_rows, strict=True):
+            if valid:
+                output[name] = row.tobytes().decode("ascii")
+    else:
+        for name, row in zip(kept_names, kept_matrix, strict=True):
+            current = row.copy()
+            current[~focus_keep] = LOWER_TRANSLATION[current[~focus_keep]]
+            if remove_indeterminate and not VALID_PREPROCESSED_BYTES[current].all():
+                continue
+            output[name] = current.tobytes().decode("ascii")
+    if not output:
+        raise ValueError("indeterminate filtering removed every sequence")
+    return output
+
+
+def extract_focus_sequences(records: OrderedDict[str, str]) -> list[str]:
+    """Extract the uppercase focus columns exactly as ProteinGym baselines do."""
+
+    if not records:
+        raise ValueError("focus extraction requires at least one record")
+    focus_sequence = next(iter(records.values()))
+    if focus_sequence and focus_sequence == focus_sequence.upper() and "-" not in focus_sequence:
+        output = list(records.values())
+        lengths = {len(sequence) for sequence in output}
+        if len(lengths) != 1:
+            raise ValueError(f"ProteinGym focus-sequence lengths disagree: {sorted(lengths)[:8]}")
+        return output
+    focus_columns = [index for index, aa in enumerate(focus_sequence) if aa != "-" and aa == aa.upper()]
+    if not focus_columns:
+        raise ValueError("no focus columns remain after preprocessing")
+    output = ["".join(sequence[index].upper() for index in focus_columns) for sequence in records.values()]
+    lengths = {len(sequence) for sequence in output}
+    if len(lengths) != 1:
+        raise ValueError(f"ProteinGym focus-sequence lengths disagree: {sorted(lengths)[:8]}")
+    return output
+
+
+def load_proteingym_focus_sequences(
+    path: str | Path,
+    *,
+    threshold_sequence_frac_gaps: float = 0.5,
+    threshold_focus_cols_frac_gaps: float = 1.0,
+    remove_indeterminate: bool = True,
+) -> tuple[list[str], dict[str, int]]:
+    """Return ProteinGym-compatible focus sequences plus prediction-side counts."""
+
+    raw_records = parse_a2m_alignment(path)
+    processed = preprocess_records_like_proteingym(
+        raw_records,
+        threshold_sequence_frac_gaps=threshold_sequence_frac_gaps,
+        threshold_focus_cols_frac_gaps=threshold_focus_cols_frac_gaps,
+        remove_indeterminate=remove_indeterminate,
+    )
+    sequences = extract_focus_sequences(processed)
+    return sequences, {
+        "msa_raw_sequences": len(raw_records),
+        "msa_processed_sequences": len(processed),
+        "msa_focus_length": len(sequences[0]),
+    }
+
+
+def load_weights(path: str | Path, n_sequences: int) -> np.ndarray:
+    """Load sequence weights and reject silent length mismatches."""
+
+    weights = np.asarray(np.load(path), dtype=np.float64).reshape(-1)
+    if len(weights) != n_sequences:
+        raise ValueError(
+            f"MSA weight length mismatch: {path}: weights={len(weights)}, sequences={n_sequences}"
+        )
+    if not np.isfinite(weights).all() or (weights < 0).any() or float(weights.sum()) <= 0:
+        raise ValueError(f"MSA weights are invalid: {path}")
+    return weights
+
+
+def weighted_conservation(
+    sequences: Iterable[str],
+    weights: np.ndarray,
+    start: int,
+    end: int,
+) -> dict[int, float]:
+    """Compute weighted entropy conservation on normalized match columns.
+
+    Positions are one-based in the reference sequence. Gaps and unknown
+    states are excluded from each column denominator. The implementation is
+    deterministic and contains no DMS-dependent operation.
+    """
+
+    records = list(sequences)
+    weights = np.asarray(weights, dtype=np.float64).reshape(-1)
+    if len(records) != len(weights):
+        raise ValueError(f"sequence/weight mismatch: {len(records)} != {len(weights)}")
+    if start < 1 or end < start:
+        raise ValueError(f"invalid MSA range: {start}-{end}")
+    if end - start + 1 > len(records[0]):
+        raise ValueError(f"MSA range exceeds aligned length: {start}-{end} > {len(records[0])}")
+
+    index = {aa: i for i, aa in enumerate(AA_ORDER)}
+    max_entropy = float(np.log(len(AA_ORDER)))
+    output: dict[int, float] = {}
+    for offset, position in enumerate(range(start, end + 1)):
+        counts = np.zeros(len(AA_ORDER), dtype=np.float64)
+        observed = 0.0
+        for sequence, weight in zip(records, weights):
+            aa = sequence[offset]
+            if aa in index:
+                counts[index[aa]] += weight
+                observed += weight
+        if observed <= 0:
+            output[position] = 0.0
+            continue
+        probabilities = counts[counts > 0] / observed
+        entropy = float(-(probabilities * np.log(probabilities)).sum())
+        output[position] = 1.0 - min(entropy / max_entropy, 1.0)
+    return output

--- a/proteingym/baselines/xsignal/xsignal_core/sensors.py
+++ b/proteingym/baselines/xsignal/xsignal_core/sensors.py
@@ -1,0 +1,422 @@
+"""Legacy-compatible corrected PureGraph GE sensors."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+
+from .a2m import AA_ORDER, load_proteingym_focus_sequences, load_weights, weighted_conservation
+from .structure import StructureContext
+
+AA_VOLUMES = {
+    "A": 88.6, "C": 108.5, "D": 111.1, "E": 138.4, "F": 189.9,
+    "G": 60.1, "H": 153.2, "I": 166.7, "K": 168.6, "L": 166.7,
+    "M": 162.9, "N": 114.1, "P": 112.7, "Q": 143.8, "R": 173.4,
+    "S": 89.0, "T": 116.1, "V": 140.0, "W": 227.8, "Y": 193.6,
+}
+AA_HYDRO = {
+    "A": 1.8, "C": 2.5, "D": -3.5, "E": -3.5, "F": 2.8,
+    "G": -0.4, "H": -3.2, "I": 4.5, "K": -3.9, "L": 3.8,
+    "M": 1.9, "N": -3.5, "P": -1.6, "Q": -3.5, "R": -4.5,
+    "S": -0.8, "T": -0.7, "V": 4.2, "W": -0.9, "Y": -1.3,
+}
+AA_STABILITY = {
+    "A": 0.0, "C": 0.3, "D": -0.9, "E": -0.8, "F": 0.5,
+    "G": -1.2, "H": -0.3, "I": 0.7, "K": -1.1, "L": 0.5,
+    "M": 0.4, "N": -0.7, "P": -0.3, "Q": -0.6, "R": -0.8,
+    "S": -0.5, "T": -0.2, "V": 0.4, "W": 1.0, "Y": 0.2,
+}
+AA_CHARGE = {
+    "A": 0, "C": 0, "D": -1, "E": -1, "F": 0, "G": 0, "H": 1,
+    "I": 0, "K": 1, "L": 0, "M": 0, "N": 0, "P": 0, "Q": 0,
+    "R": 1, "S": 0, "T": 0, "V": 0, "W": 0, "Y": 0,
+}
+MUTATION_RE = re.compile(r"^([A-Z])(\d+)([A-Z])$")
+AA_TO_INDEX = {aa: index for index, aa in enumerate(AA_ORDER)}
+GAP_STATE = len(AA_ORDER)
+
+
+def parse_single_mutation(value: str) -> tuple[str, int, str] | None:
+    """Parse only a single substitution; leave multi-mutants for a later track."""
+
+    match = MUTATION_RE.fullmatch(str(value).strip())
+    if not match:
+        return None
+    wt, position, mutant = match.groups()
+    return wt, int(position), mutant
+
+
+def parse_mutation_tokens(value: str) -> list[tuple[str, int, str]]:
+    """Parse all substitution tokens separated by ':'."""
+
+    parsed: list[tuple[str, int, str]] = []
+    for token in str(value).strip().split(":"):
+        match = MUTATION_RE.fullmatch(token.strip())
+        if not match:
+            continue
+        wt, position, mutant = match.groups()
+        parsed.append((wt, int(position), mutant))
+    return parsed
+
+
+def required_position_pairs(values: list[str] | tuple[str, ...] | np.ndarray) -> set[tuple[int, int]]:
+    pairs: set[tuple[int, int]] = set()
+    for value in values:
+        positions = sorted({position for _wt, position, _mutant in parse_mutation_tokens(str(value))})
+        for left_index, left in enumerate(positions):
+            for right in positions[left_index + 1 :]:
+                pairs.add((left, right))
+    return pairs
+
+
+def _mutation_delta_vector(parsed: tuple[str, int, str]) -> dict[str, float]:
+    wt, _position, mutant = parsed
+    return {
+        "hydro": (AA_HYDRO.get(mutant, 0.0) - AA_HYDRO.get(wt, 0.0)) / 9.0,
+        "volume": (AA_VOLUMES.get(mutant, 130.0) - AA_VOLUMES.get(wt, 130.0)) / max(AA_VOLUMES.values()),
+        "charge": float(AA_CHARGE.get(mutant, 0) - AA_CHARGE.get(wt, 0)),
+        "to_pro": float(mutant == "P") - float(wt == "P"),
+        "to_gly": float(mutant == "G") - float(wt == "G"),
+        "to_cys": float(mutant == "C") - float(wt == "C"),
+    }
+
+
+def _structure_context_single(parsed: tuple[str, int, str], structure: StructureContext, pdb_start: int) -> float:
+    wt, position, mutant = parsed
+    index = structure.index_for_alignment_position(position, pdb_start)
+    if index is None:
+        return 0.0
+    burial = float(structure.burial[index])
+    confidence = float(structure.plddt[index])
+    if burial < 0.15:
+        return 0.0
+    importance = burial * (0.5 + 0.5 * confidence)
+    delta_volume = abs(AA_VOLUMES.get(mutant, 130.0) - AA_VOLUMES.get(wt, 130.0)) / max(AA_VOLUMES.values())
+    wt_hydro = AA_HYDRO.get(wt, 0.0)
+    mutant_hydro = AA_HYDRO.get(mutant, 0.0)
+    hydro_penalty = 0.0
+    if wt_hydro > 1.0 and mutant_hydro < -1.0:
+        hydro_penalty = 1.0
+    elif wt_hydro < -1.0 and mutant_hydro > 1.0:
+        hydro_penalty = 0.8
+    elif abs(wt_hydro - mutant_hydro) > 3.0:
+        hydro_penalty = 0.5
+    aa_penalty = 0.0
+    if mutant == "P" and wt != "P":
+        aa_penalty = 0.5
+    if wt == "C" and mutant != "C":
+        aa_penalty = 1.0
+    if mutant == "G" and wt != "G":
+        aa_penalty = 0.3
+    disruption = importance * max(delta_volume * 0.7 + hydro_penalty * 0.3, aa_penalty * 0.15)
+    return float(-disruption)
+
+
+def structure_context_score(value: str, structure: StructureContext, pdb_start: int) -> float:
+    parsed = parse_single_mutation(value)
+    if parsed is None:
+        return 0.0
+    return _structure_context_single(parsed, structure, pdb_start)
+
+
+def _tm_stability_single(parsed: tuple[str, int, str], structure: StructureContext, pdb_start: int) -> float:
+    wt, position, mutant = parsed
+    index = structure.index_for_alignment_position(position, pdb_start)
+    if index is None:
+        return 0.0
+    burial = float(structure.burial[index])
+    confidence = float(structure.plddt[index])
+    delta_tm = AA_STABILITY.get(mutant, 0.0) - AA_STABILITY.get(wt, 0.0)
+    delta_charge = AA_CHARGE.get(mutant, 0) - AA_CHARGE.get(wt, 0)
+    return float(burial * delta_tm * confidence + (1.0 - burial) * abs(delta_charge) * 0.15 * confidence)
+
+
+def tm_stability_score(value: str, structure: StructureContext, pdb_start: int) -> float:
+    parsed = parse_single_mutation(value)
+    if parsed is None:
+        return 0.0
+    return _tm_stability_single(parsed, structure, pdb_start)
+
+
+def _msa_structure_joint_single(
+    parsed: tuple[str, int, str],
+    conservation: dict[int, float],
+    structure: StructureContext,
+    pdb_start: int,
+) -> float:
+    wt, position, mutant = parsed
+    index = structure.index_for_alignment_position(position, pdb_start)
+    if index is None:
+        return 0.0
+    cons = float(conservation.get(position, 0.0))
+    burial = float(structure.burial[index])
+    confidence = float(structure.plddt[index])
+    delta_volume = abs(AA_VOLUMES.get(mutant, 130.0) - AA_VOLUMES.get(wt, 130.0)) / max(AA_VOLUMES.values())
+    wt_hydro = AA_HYDRO.get(wt, 0.0)
+    mutant_hydro = AA_HYDRO.get(mutant, 0.0)
+    bio_penalty = 0.0
+    if wt_hydro > 1.0 and mutant_hydro < -1.0:
+        bio_penalty = 1.0
+    elif wt_hydro < -1.0 and mutant_hydro > 1.0:
+        bio_penalty = 0.8
+    elif abs(wt_hydro - mutant_hydro) > 3.0:
+        bio_penalty = 0.5
+    if mutant == "P" and wt != "P":
+        bio_penalty = max(bio_penalty, 0.5)
+    if wt == "C" and mutant != "C":
+        bio_penalty = max(bio_penalty, 1.0)
+    core_score = burial * delta_volume * (0.5 + 0.5 * cons)
+    functional_score = (1.0 - burial) * cons * bio_penalty
+    return float(-(core_score * 0.65 + functional_score * 0.35) * confidence)
+
+
+def msa_structure_joint_score(
+    value: str,
+    conservation: dict[int, float],
+    structure: StructureContext,
+    pdb_start: int,
+) -> float:
+    parsed = parse_single_mutation(value)
+    if parsed is None:
+        return 0.0
+    return _msa_structure_joint_single(parsed, conservation, structure, pdb_start)
+
+
+def _mean_over_valid(values: list[float]) -> float:
+    return float(np.mean(values)) if values else 0.0
+
+
+def structure_context_composable_score(value: str, structure: StructureContext, pdb_start: int) -> float:
+    return _mean_over_valid(
+        [
+            _structure_context_single(parsed, structure, pdb_start)
+            for parsed in parse_mutation_tokens(value)
+        ]
+    )
+
+
+def tm_stability_composable_score(value: str, structure: StructureContext, pdb_start: int) -> float:
+    return _mean_over_valid(
+        [
+            _tm_stability_single(parsed, structure, pdb_start)
+            for parsed in parse_mutation_tokens(value)
+        ]
+    )
+
+
+def msa_structure_joint_composable_score(
+    value: str,
+    conservation: dict[int, float],
+    structure: StructureContext,
+    pdb_start: int,
+) -> float:
+    return _mean_over_valid(
+        [
+            _msa_structure_joint_single(parsed, conservation, structure, pdb_start)
+            for parsed in parse_mutation_tokens(value)
+        ]
+    )
+
+
+def contact_pair_ge_score(
+    value: str,
+    structure: StructureContext,
+    pdb_start: int,
+    *,
+    contact_radius: float = 8.0,
+) -> float:
+    parsed_tokens = parse_mutation_tokens(value)
+    if len(parsed_tokens) < 2:
+        return 0.0
+
+    indexed: list[tuple[int, dict[str, float]]] = []
+    for parsed in parsed_tokens:
+        index = structure.index_for_alignment_position(parsed[1], pdb_start)
+        if index is None:
+            continue
+        indexed.append((index, _mutation_delta_vector(parsed)))
+    if len(indexed) < 2:
+        return 0.0
+
+    pair_scores: list[float] = []
+    for left_offset, (left_index, left_vec) in enumerate(indexed):
+        for right_index, right_vec in indexed[left_offset + 1 :]:
+            distance = structure.pair_distance(left_index, right_index)
+            if not np.isfinite(distance) or distance <= 0.0 or distance > contact_radius:
+                continue
+            local_burial = 0.5 * (float(structure.burial[left_index]) + float(structure.burial[right_index]))
+            confidence = np.sqrt(float(structure.plddt[left_index]) * float(structure.plddt[right_index]))
+            contact_weight = np.exp(-((distance / 6.5) ** 2)) * confidence * (0.35 + 0.65 * local_burial)
+
+            same_charge = max(0.0, left_vec["charge"] * right_vec["charge"])
+            opposite_charge = max(0.0, -left_vec["charge"] * right_vec["charge"])
+            dual_expand = max(0.0, left_vec["volume"]) * max(0.0, right_vec["volume"])
+            dual_shrink = max(0.0, -left_vec["volume"]) * max(0.0, -right_vec["volume"])
+            volume_comp = max(0.0, -left_vec["volume"] * right_vec["volume"])
+            hydro_mismatch = abs(left_vec["hydro"] - right_vec["hydro"])
+            special = (
+                abs(left_vec["to_pro"]) + abs(right_vec["to_pro"])
+                + 0.6 * (abs(left_vec["to_gly"]) + abs(right_vec["to_gly"]))
+                + 0.4 * (abs(left_vec["to_cys"]) + abs(right_vec["to_cys"]))
+            )
+
+            penalty = (
+                0.55 * same_charge
+                + 0.35 * dual_expand
+                + 0.22 * dual_shrink
+                + 0.18 * hydro_mismatch
+                + 0.14 * special
+            )
+            compensation = 0.28 * opposite_charge + 0.14 * volume_comp
+            pair_scores.append(float(contact_weight * (compensation - penalty)))
+    return _mean_over_valid(pair_scores)
+
+
+def build_msa_pair_log_tables_with_metadata(
+    msa_path: str | Path,
+    weight_path: str | Path,
+    start: int,
+    end: int,
+    mutant_values: list[str] | tuple[str, ...] | np.ndarray,
+    *,
+    pseudocount: float = 0.5,
+) -> tuple[dict[tuple[int, int], np.ndarray], dict[str, int]]:
+    sequences, metadata = load_proteingym_focus_sequences(
+        msa_path,
+        threshold_sequence_frac_gaps=0.5,
+        threshold_focus_cols_frac_gaps=1.0,
+        remove_indeterminate=True,
+    )
+    expected_length = end - start + 1
+    if metadata["msa_focus_length"] != expected_length:
+        raise ValueError(
+            f"MSA focus length mismatch: {msa_path}: focus={metadata['msa_focus_length']}, expected={expected_length}"
+        )
+    weights = load_weights(weight_path, len(sequences))
+    pairs = required_position_pairs(mutant_values)
+    if not pairs:
+        meta = dict(metadata)
+        meta["msa_weight_sequences"] = int(len(weights))
+        meta["msa_weight_sum_floor"] = int(np.floor(weights.sum()))
+        meta["msa_pair_requested"] = 0
+        meta["msa_pair_scored"] = 0
+        return {}, meta
+
+    selected_positions = sorted({position for pair in pairs for position in pair if start <= position <= end})
+    position_to_col = {position: index for index, position in enumerate(selected_positions)}
+    state_matrix = np.full((len(sequences), len(selected_positions)), GAP_STATE, dtype=np.int16)
+    for row_index, sequence in enumerate(sequences):
+        for col_index, position in enumerate(selected_positions):
+            aa = sequence[position - start]
+            state_matrix[row_index, col_index] = AA_TO_INDEX.get(aa, GAP_STATE)
+
+    n_states = len(AA_ORDER) + 1
+    total = float(weights.sum()) + pseudocount * (n_states * n_states)
+    tables: dict[tuple[int, int], np.ndarray] = {}
+    for left, right in sorted(pairs):
+        left_col = position_to_col.get(left)
+        right_col = position_to_col.get(right)
+        if left_col is None or right_col is None:
+            continue
+        keys = state_matrix[:, left_col].astype(np.int32) * n_states + state_matrix[:, right_col].astype(np.int32)
+        counts = np.bincount(keys, weights=weights, minlength=n_states * n_states).astype(np.float64)
+        probs = (counts.reshape(n_states, n_states) + pseudocount) / total
+        tables[(left, right)] = np.log(np.clip(probs[: len(AA_ORDER), : len(AA_ORDER)], 1e-12, 1.0))
+
+    meta = dict(metadata)
+    meta["msa_weight_sequences"] = int(len(weights))
+    meta["msa_weight_sum_floor"] = int(np.floor(weights.sum()))
+    meta["msa_pair_requested"] = int(len(pairs))
+    meta["msa_pair_scored"] = int(len(tables))
+    return tables, meta
+
+
+def contact_evo_pair_ge_score(
+    value: str,
+    pair_log_tables: dict[tuple[int, int], np.ndarray],
+    structure: StructureContext,
+    pdb_start: int,
+    *,
+    contact_radius: float = 8.0,
+) -> float:
+    parsed_tokens = parse_mutation_tokens(value)
+    if len(parsed_tokens) < 2:
+        return 0.0
+
+    indexed: list[tuple[int, int, tuple[str, int, str]]] = []
+    for parsed in parsed_tokens:
+        index = structure.index_for_alignment_position(parsed[1], pdb_start)
+        if index is None:
+            continue
+        indexed.append((parsed[1], index, parsed))
+    if len(indexed) < 2:
+        return 0.0
+
+    pair_scores: list[float] = []
+    for left_offset, (left_pos, left_index, left_parsed) in enumerate(indexed):
+        for right_pos, right_index, right_parsed in indexed[left_offset + 1 :]:
+            distance = structure.pair_distance(left_index, right_index)
+            if not np.isfinite(distance) or distance <= 0.0 or distance > contact_radius:
+                continue
+
+            swapped = False
+            pair = (left_pos, right_pos)
+            if left_pos > right_pos:
+                pair = (right_pos, left_pos)
+                swapped = True
+            table = pair_log_tables.get(pair)
+            if table is None:
+                continue
+            parsed_left = right_parsed if swapped else left_parsed
+            parsed_right = left_parsed if swapped else right_parsed
+            wt_left, _pos_left, mt_left = parsed_left
+            wt_right, _pos_right, mt_right = parsed_right
+            wt_left_index = AA_TO_INDEX.get(wt_left)
+            wt_right_index = AA_TO_INDEX.get(wt_right)
+            mt_left_index = AA_TO_INDEX.get(mt_left)
+            mt_right_index = AA_TO_INDEX.get(mt_right)
+            if None in {wt_left_index, wt_right_index, mt_left_index, mt_right_index}:
+                continue
+
+            log_wt_wt = float(table[wt_left_index, wt_right_index])
+            log_mt_mt = float(table[mt_left_index, mt_right_index])
+            log_mt_wt = float(table[mt_left_index, wt_right_index])
+            log_wt_mt = float(table[wt_left_index, mt_right_index])
+            epistasis = log_mt_mt + log_wt_wt - log_mt_wt - log_wt_mt
+
+            local_burial = 0.5 * (float(structure.burial[left_index]) + float(structure.burial[right_index]))
+            confidence = np.sqrt(float(structure.plddt[left_index]) * float(structure.plddt[right_index]))
+            contact_weight = np.exp(-((distance / 6.5) ** 2)) * confidence * (0.35 + 0.65 * local_burial)
+            pair_scores.append(float(contact_weight * epistasis))
+    return _mean_over_valid(pair_scores)
+
+
+def corrected_msa_conservation_with_metadata(
+    msa_path: str | Path,
+    weight_path: str | Path,
+    start: int,
+    end: int,
+) -> tuple[dict[int, float], dict[str, int]]:
+    sequences, metadata = load_proteingym_focus_sequences(
+        msa_path,
+        threshold_sequence_frac_gaps=0.5,
+        threshold_focus_cols_frac_gaps=1.0,
+        remove_indeterminate=True,
+    )
+    expected_length = end - start + 1
+    if metadata["msa_focus_length"] != expected_length:
+        raise ValueError(
+            f"MSA focus length mismatch: {msa_path}: focus={metadata['msa_focus_length']}, expected={expected_length}"
+        )
+    weights = load_weights(weight_path, len(sequences))
+    metadata = dict(metadata)
+    metadata["msa_weight_sequences"] = int(len(weights))
+    metadata["msa_weight_sum_floor"] = int(np.floor(weights.sum()))
+    return weighted_conservation(sequences, weights, start, end), metadata
+
+
+def corrected_msa_conservation(msa_path: str | Path, weight_path: str | Path, start: int, end: int) -> dict[int, float]:
+    conservation, _ = corrected_msa_conservation_with_metadata(msa_path, weight_path, start, end)
+    return conservation

--- a/proteingym/baselines/xsignal/xsignal_core/structure.py
+++ b/proteingym/baselines/xsignal/xsignal_core/structure.py
@@ -1,0 +1,110 @@
+"""AF2 structure parsing with length-independent residue geometry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from Bio.PDB import PDBParser
+from Bio.PDB.SASA import ShrakeRupley
+
+THREE_TO_ONE = {
+    "ALA": "A", "CYS": "C", "ASP": "D", "GLU": "E", "PHE": "F",
+    "GLY": "G", "HIS": "H", "ILE": "I", "LYS": "K", "LEU": "L",
+    "MET": "M", "ASN": "N", "PRO": "P", "GLN": "Q", "ARG": "R",
+    "SER": "S", "THR": "T", "VAL": "V", "TRP": "W", "TYR": "Y",
+}
+
+
+@dataclass(frozen=True)
+class StructureContext:
+    """Residue-indexed structure quantities for one selected AF2 chain."""
+
+    residue_keys: tuple[tuple[str, int, str], ...]
+    aa: tuple[str, ...]
+    xyz: np.ndarray
+    burial: np.ndarray
+    plddt: np.ndarray
+    contact_count: np.ndarray
+
+    def index_for_alignment_position(self, position: int, pdb_start: int) -> int | None:
+        """Map a DMS/MSA one-based position to sequential PDB residue index."""
+
+        index = position - pdb_start
+        if index < 0 or index >= len(self.aa):
+            return None
+        return index
+
+    def pair_distance(self, left_index: int, right_index: int) -> float:
+        return float(np.linalg.norm(self.xyz[left_index] - self.xyz[right_index]))
+
+
+def _select_chain(model, chain_id: str | None):
+    chains = list(model.get_chains())
+    if chain_id is not None:
+        for chain in chains:
+            if chain.id == chain_id:
+                return chain
+        raise ValueError(f"requested PDB chain is missing: {chain_id}")
+    for chain in chains:
+        if chain.id == "A":
+            return chain
+    if not chains:
+        raise ValueError("AF2 structure contains no chains")
+    return chains[0]
+
+
+def parse_af2_structure(
+    path: str | Path,
+    *,
+    chain_id: str | None = None,
+    contact_radius: float = 8.0,
+) -> StructureContext:
+    """Parse standard residues and compute relative SASA, contacts, pLDDT.
+
+    Burial is the within-protein percentile rank of negative residue SASA.
+    This avoids the invalid contact-count / protein-length normalization used
+    by legacy PureGraph sensors. C-alpha is used for Gly and C-beta otherwise,
+    so Gly residues are covered rather than silently dropped.
+    """
+
+    parser = PDBParser(QUIET=True)
+    structure = parser.get_structure("puregraph", str(path))
+    model = next(structure.get_models())
+    chain = _select_chain(model, chain_id)
+    residues = [
+        residue for residue in chain.get_residues()
+        if residue.resname in THREE_TO_ONE and "CA" in residue
+    ]
+    if len(residues) < 2:
+        raise ValueError(f"AF2 chain has fewer than two standard residues: {path}")
+
+    # Biopython's Shrake-Rupley computes residue SASA from the complete atom set.
+    ShrakeRupley(probe_radius=1.4, n_points=100).compute(model, level="R")
+    sasa = np.asarray([float(getattr(residue, "sasa", np.nan)) for residue in residues])
+    if not np.isfinite(sasa).all():
+        raise ValueError(f"AF2 residue SASA contains non-finite values: {path}")
+
+    coords = []
+    plddt = []
+    for residue in residues:
+        atom = residue["CB"] if "CB" in residue else residue["CA"]
+        coords.append(np.asarray(atom.coord, dtype=np.float64))
+        plddt.append(float(residue["CA"].bfactor))
+    xyz = np.asarray(coords)
+    distances = np.sqrt(((xyz[:, None, :] - xyz[None, :, :]) ** 2).sum(axis=2))
+    contact_count = ((distances < contact_radius) & (distances > 0)).sum(axis=1).astype(np.float64)
+    # Percentile rank is deterministic and invariant to protein length.
+    burial = pd.Series(-sasa).rank(method="average", pct=True).to_numpy(dtype=np.float64)
+    confidence = np.clip(np.asarray(plddt, dtype=np.float64) / 100.0, 0.0, 1.0)
+    keys = tuple((chain.id, int(residue.id[1]), residue.resname) for residue in residues)
+    return StructureContext(
+        residue_keys=keys,
+        aa=tuple(THREE_TO_ONE[residue.resname] for residue in residues),
+        xyz=xyz,
+        burial=burial,
+        plddt=confidence,
+        contact_count=contact_count,
+    )

--- a/scripts/scoring_DMS_zero_shot/scoring_XSignal_substitutions.sh
+++ b/scripts/scoring_DMS_zero_shot/scoring_XSignal_substitutions.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+source ../zero_shot_config.sh
+
+# XSignal uses ProteinGym substitution assay files, ProteinGym MSA files,
+# ProteinGym MSA weights, precomputed ProteinGym AF2 structures, and ten
+# self-generated intermediate XSignal sensor score folders.
+#
+# Required folder layout for legacy intermediates:
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureRSALORLike_v1/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureContextRank_v1/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureFamilyConvMLM_v1/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureFamilyVAE_v1/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureStructureEnergy_v1/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PurePottsPLL_v1/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureTTPhysics_v1/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureContextualMSA_v1b/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureSubfamilyMSA_v1/*.csv
+# ${XSIGNAL_LEGACY_SCORE_FOLDER}/PureStructureGraph_v1/*.csv
+
+export output_scores_folder="${DMS_output_score_folder_subs}/XSignal"
+export DMS_index="${DMS_index:-0}"
+export XSIGNAL_LEGACY_SCORE_FOLDER="${XSIGNAL_LEGACY_SCORE_FOLDER:-${DMS_output_score_folder_subs}}"
+
+mkdir -p "${output_scores_folder}"
+
+python ../../../proteingym/baselines/xsignal/compute_fitness.py \
+  --DMS_reference_file_path "${DMS_reference_file_path_subs}" \
+  --DMS_data_folder "${DMS_data_folder_subs}" \
+  --DMS_index "${DMS_index}" \
+  --output_scores_folder "${output_scores_folder}" \
+  --MSA_folder "${DMS_MSA_data_folder}" \
+  --MSA_weights_folder "${DMS_MSA_weights_folder}" \
+  --AF2_structures_folder "${DMS_structure_folder}" \
+  --legacy_score_folder "${XSIGNAL_LEGACY_SCORE_FOLDER}"


### PR DESCRIPTION
## Summary

This PR adds XSignal, a zero-shot evidence-integration baseline for ProteinGym substitution assays. XSignal derives 14 mutation-scoring channels from ProteinGym MSAs, MSA weights, precomputed AlphaFold2 structures, and fixed amino-acid physicochemical descriptors. Each channel is transformed to assay-wise percentile ranks and the final score is an equal-weight average.

The final scorer reads only variant-key columns from DMS assay CSVs (`mutant`, `mutated_sequence`). It does not read DMS labels, binary labels, supervised folds, public baseline score packages, or official merged-score files during final scoring. XSignal uses no pretrained protein language model weights; it does use precomputed AlphaFold2 structures and ten self-generated intermediate evidence score directories.

## Score Package

Audited release: https://github.com/Billwanttobetop/ProteinGym/releases/tag/xsignal-proteingym-scores-20260723-audited

Score asset: `XSignal_scores_substitutions_20260723.zip`

- 217 ProteinGym substitution assays
- 2,465,767 variants
- columns: `mutant`, `mutated_sequence`, `XSignal_score`
- SHA256: `0e3c9fa348d83b60e23ee3f57a7c1d517ea1109cc277556bdc8598762538b367`

## Evaluation

Official ProteinGym wrapper metrics on the full substitution benchmark:

| Metric | Score |
|---|---:|
| Spearman | 0.476 |
| AUC | 0.761 |
| MCC | 0.369 |
| NDCG | 0.778 |
| Top recall | 0.213 |

A full final-fusion reproduction regenerated 217 assay score files / 2,465,767 variants from the archived upstream XSignal sensor outputs plus ProteinGym MSA weights and AF2 structures, matching the frozen internal candidate `PureGraphGEContactPair_v1` with `max_abs_diff = 0.0`. The release also includes a compact audit/provenance bundle.

## Scope Boundary

This submission is for the frozen XSignal substitution score package only. Public RefSeq MSA expansion experiments and private/non-public datasets are not included.
